### PR TITLE
PA-460 alles neu

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "dependencies": {
         "@pinuts/eslint-config-pinuts-base": "^2.0.0",
         "babel-eslint": "^10.0.1",
-        "eslint-loader": "^2.1.2",
-        "eslint-plugin-import": "^2.16.0",
-        "eslint-plugin-jsx-a11y": "^6.2.1",
-        "eslint-plugin-graphql": "^3.0.3",
-        "eslint-plugin-node": "^8.0.1",
-        "eslint-plugin-promise": "^4.0.1",
-        "eslint-plugin-react": "^7.12.4"
+        "eslint-loader": "^4.0.2",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-graphql": "^4.0.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0"
     },
     "peerDependencies": {}
 }


### PR DESCRIPTION
Hallo @workflo ,

ich habe hier mal alle Pakete aktualisiert.
Siehe PA-460 Eslint: pinuts / eslint-config-pinuts-react geht nicht mit aktuellen react-scripts

gruesse Stephan
